### PR TITLE
Add pages for Codex and GPT-O3

### DIFF
--- a/codex.html
+++ b/codex.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html lang="zh">
+<head>
+    <meta charset="UTF-8">
+    <title>Codex</title>
+    <link rel="stylesheet" href="style.css">
+</head>
+<body class="codex">
+    <header>
+        <div class="logo">OpenAI</div>
+    </header>
+    <main>
+        <h1><strong>Codex</strong></h1>
+        <p>Codex是OpenAI开发的一种强大的人工智能编程模型，是GPT系列的延伸，专门针对编程任务进行了优化。它于2021年首次发布，核心基于GPT-3，并在大量开源代码（如GitHub上的项目）上进行了训练，具备理解自然语言并将其转化为计算机代码的能力。</p>
+        <p>Codex能够支持十几种主流编程语言，包括Python、JavaScript、Java、Go、Ruby、C++等，最擅长的是Python。用户可以用自然语言描述想要实现的功能，Codex便能自动生成相应的代码。这使得它广泛应用于自动化编程、代码补全、调试、API调用生成、数据分析脚本编写等领域。</p>
+        <p>Codex是GitHub Copilot的技术核心，为程序员提供“AI 编程助手”体验，大幅提升编码效率。同时，它也被集成进OpenAI的ChatGPT中，在“代码解释与生成”方面表现出色。</p>
+    </main>
+</body>
+</html>

--- a/gpt-o3.html
+++ b/gpt-o3.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<html lang="zh">
+<head>
+    <meta charset="UTF-8">
+    <title>GPT-O3</title>
+    <link rel="stylesheet" href="style.css">
+</head>
+<body class="o3">
+    <header>
+        <div class="logo">OpenAI</div>
+    </header>
+    <main>
+        <h1><strong>O3</strong></h1>
+        <p>OpenAI o3 是 OpenAI 于 2024 年 12 月首次发布的“推理（reasoning）”系列大型语言模型中的旗舰版本，定位在 GPT 系列之后，专注于复杂推理、逻辑分析与多模态工具整合  ￼。</p>
+        <ul>
+            <li>发布时间线：</li>
+            <li>2024 年 12 月 20 日正式宣布 o3 系列（包括 o3 与 o3‑mini）  ￼；</li>
+            <li>o3‑mini 于 2025 年 1 月 31 日上线；o3 正式版本于 2025 年 4 月 16 日发布，并在 6 月 10 日升级出 o3‑pro  ￼。</li>
+            <li>核心特点：</li>
+            <li>引入“private chain of thought”（私有思维链），让模型在生成答案前进行内部推理，类似人类“思考”  ￼；</li>
+            <li>强调逐步逻辑分析，适合处理复杂数学、科学、编程与视觉输入问题  ￼；</li>
+            <li>支持自动调用各种工具（例如：网络搜索、代码执行、图像分析与生成）来辅助问题解答  ￼。</li>
+            <li>性能表现：</li>
+            <li>在专业学术与编程任务中成绩显著：GPQA Diamond（87.7%）、SWE‑bench Verified（71.7%）、Codeforces Elo 2727（远超 o1 的 1891）  ￼；</li>
+            <li>在 ARC‑AGI 推理评测中表现是 o1 的三倍  ￼；</li>
+            <li>在复杂法律测试中表现如 A+ 法学生等级  ￼。</li>
+            <li>进阶版本 o3‑pro：于 2025 年 6 月 10 日发布，延长思考时长以增强可靠性，专为最具挑战性的任务设计，适用于 ChatGPT Pro 和 API 用户  ￼。</li>
+            <li>局限与挑战：</li>
+            <li>虽在多项任务中突破性提升，但仍存在“跳脱事实”或“编造信息”的情况，在部分任务中甚至比 o1 报错率更高  ￼；</li>
+            <li>处理速度较慢，复杂推理往往需几十秒至数分钟 。“</li>
+        </ul>
+    </main>
+</body>
+</html>

--- a/index.html
+++ b/index.html
@@ -10,10 +10,19 @@
         <div class="logo">OpenAI</div>
     </header>
     <main>
-        <h1>OpenAI</h1>
-        <p>OpenAI是一家位于美国的人工智能研究与开发公司，成立于2015年，总部设在旧金山。公司最初由埃隆·马斯克（Elon Musk）、山姆·奥特曼（Sam Altman）等人共同创立，旨在“确保通用人工智能（AGI）造福全人类”。OpenAI致力于推动人工智能的安全发展，并推动相关技术的开放与普及。</p>
-        <p>OpenAI的代表性成果包括GPT系列语言模型（Generative Pre-trained Transformer），如GPT-3、GPT-4和目前的GPT-4o等，这些模型在自然语言处理、文本生成、翻译、写作、编程辅助等领域取得了广泛应用。除了文本模型，OpenAI还开发了图像生成模型DALL·E、多模态交互模型、代码生成模型Codex等。</p>
-        <p>目前，OpenAI以“对齐人工智能与人类利益”为核心目标，在透明性、安全性与全球合作方面持续推进，积极探索AGI的发展路径，推动技术服务于教育、医疗、科研、创意产业等多个领域。</p>
+        <div class="container">
+            <div class="text">
+                <h1>OpenAI</h1>
+                <p>OpenAI是一家位于美国的人工智能研究与开发公司，成立于2015年，总部设在旧金山。公司最初由埃隆·马斯克（Elon Musk）、山姆·奥特曼（Sam Altman）等人共同创立，旨在“确保通用人工智能（AGI）造福全人类”。OpenAI致力于推动人工智能的安全发展，并推动相关技术的开放与普及。</p>
+                <p>OpenAI的代表性成果包括GPT系列语言模型（Generative Pre-trained Transformer），如GPT-3、GPT-4和目前的GPT-4o等，这些模型在自然语言处理、文本生成、翻译、写作、编程辅助等领域取得了广泛应用。除了文本模型，OpenAI还开发了图像生成模型DALL·E、多模态交互模型、代码生成模型Codex等。</p>
+                <p>目前，OpenAI以“对齐人工智能与人类利益”为核心目标，在透明性、安全性与全球合作方面持续推进，积极探索AGI的发展路径，推动技术服务于教育、医疗、科研、创意产业等多个领域。</p>
+            </div>
+            <img src="Screenshot%202025-06-19%20at%2011.54.34.png" alt="OpenAI" class="photo">
+        </div>
+        <div class="buttons">
+            <a href="codex.html" class="btn">Codex</a>
+            <a href="gpt-o3.html" class="btn">GPT-O3</a>
+        </div>
     </main>
 </body>
 </html>

--- a/style.css
+++ b/style.css
@@ -2,6 +2,7 @@ body {
     font-family: Arial, sans-serif;
     margin: 0;
     padding: 0;
+    background-color: #eee;
 }
 
 header {
@@ -20,4 +21,43 @@ header {
 main {
     padding: 20px;
     line-height: 1.6;
+}
+
+.container {
+    display: flex;
+    justify-content: space-between;
+    align-items: flex-start;
+}
+
+.text {
+    flex: 1;
+    margin-right: 20px;
+}
+
+.photo {
+    width: 300px;
+    border-radius: 20px;
+}
+
+.buttons {
+    display: flex;
+    gap: 20px;
+    padding: 20px;
+}
+
+.btn {
+    background-color: #fff;
+    padding: 10px 20px;
+    border-radius: 10px;
+    text-decoration: none;
+    color: #333;
+    box-shadow: 0 0 5px rgba(0,0,0,0.1);
+}
+
+body.codex {
+    background-color: #e6f0ff;
+}
+
+body.o3 {
+    background-color: #fff9b1;
 }


### PR DESCRIPTION
## Summary
- style updates for layout and new buttons
- add navigation to Codex and GPT-O3 pages
- create Codex description page with light blue background
- create GPT-O3 description page with bright yellow background

## Testing
- `echo 'no tests'`

------
https://chatgpt.com/codex/tasks/task_e_68538dce2ba48332ad6d3adba7ea0307