### PR TITLE
Adjust homepage image and add scroll console

### DIFF
--- a/codex.html
+++ b/codex.html
@@ -14,6 +14,8 @@
         <p>Codex是OpenAI开发的一种强大的人工智能编程模型，是GPT系列的延伸，专门针对编程任务进行了优化。它于2021年首次发布，核心基于GPT-3，并在大量开源代码（如GitHub上的项目）上进行了训练，具备理解自然语言并将其转化为计算机代码的能力。</p>
         <p>Codex能够支持十几种主流编程语言，包括Python、JavaScript、Java、Go、Ruby、C++等，最擅长的是Python。用户可以用自然语言描述想要实现的功能，Codex便能自动生成相应的代码。这使得它广泛应用于自动化编程、代码补全、调试、API调用生成、数据分析脚本编写等领域。</p>
         <p>Codex是GitHub Copilot的技术核心，为程序员提供“AI 编程助手”体验，大幅提升编码效率。同时，它也被集成进OpenAI的ChatGPT中，在“代码解释与生成”方面表现出色。</p>
+    <video src="media/optimised.mp4" controls class="video"></video>
     </main>
+    <script src="script.js"></script>
 </body>
 </html>

--- a/gpt-o3.html
+++ b/gpt-o3.html
@@ -30,5 +30,6 @@
             <li>处理速度较慢，复杂推理往往需几十秒至数分钟。</li>
         </ul>
     </main>
+    <script src="script.js"></script>
 </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -17,12 +17,13 @@
                 <p>OpenAI的代表性成果包括GPT系列语言模型（Generative Pre-trained Transformer），如GPT-3、GPT-4和目前的GPT-4o等，这些模型在自然语言处理、文本生成、翻译、写作、编程辅助等领域取得了广泛应用。除了文本模型，OpenAI还开发了图像生成模型DALL·E、多模态交互模型、代码生成模型Codex等。</p>
                 <p>目前，OpenAI以“对齐人工智能与人类利益”为核心目标，在透明性、安全性与全球合作方面持续推进，积极探索AGI的发展路径，推动技术服务于教育、医疗、科研、创意产业等多个领域。</p>
             </div>
-            <img src="Screenshot%202025-06-19%20at%2011.54.34.png" alt="OpenAI" class="photo">
+            <img src="media/Screenshot 2025-06-19 at 11.54.34.png" alt="OpenAI" class="photo">
         </div>
         <div class="buttons">
             <a href="codex.html" class="btn">Codex</a>
             <a href="gpt-o3.html" class="btn">GPT-O3</a>
         </div>
-    </main>
+</main>
+<script src="script.js"></script>
 </body>
 </html>

--- a/script.js
+++ b/script.js
@@ -1,0 +1,11 @@
+let lastScroll = 0;
+const header = document.querySelector('header');
+window.addEventListener('scroll', () => {
+  const current = window.pageYOffset || document.documentElement.scrollTop;
+  if (current > lastScroll) {
+    header.classList.add('hide');
+  } else {
+    header.classList.remove('hide');
+  }
+  lastScroll = current <= 0 ? 0 : current;
+});

--- a/style.css
+++ b/style.css
@@ -2,6 +2,7 @@ body {
     font-family: Arial, sans-serif;
     margin: 0;
     padding: 0;
+    padding-top: 60px;
     background-color: #eee;
 }
 
@@ -11,6 +12,18 @@ header {
     align-items: center;
     padding: 10px 20px;
     background-color: #f2f2f2;
+    height: 60px;
+    position: fixed;
+    top: 0;
+    left: 0;
+    width: 100%;
+    transition: top 0.3s;
+    box-shadow: 0 2px 5px rgba(0,0,0,0.1);
+    z-index: 1000;
+}
+
+header.hide {
+    top: -60px;
 }
 
 .logo {
@@ -25,24 +38,28 @@ main {
 
 .container {
     display: flex;
-    justify-content: space-between;
-    align-items: flex-start;
+    align-items: center;
+    gap: 20px;
 }
 
 .text {
-    flex: 1;
+    flex: 2;
     margin-right: 20px;
 }
 
 .photo {
-    width: 300px;
+    flex: 1;
+    width: 100%;
+    max-width: 100%;
     border-radius: 20px;
 }
 
 .buttons {
     display: flex;
+    justify-content: center;
     gap: 20px;
     padding: 20px;
+    width: 100%;
 }
 
 .btn {
@@ -60,4 +77,11 @@ body.codex {
 
 body.o3 {
     background-color: #fff9b1;
+}
+
+.video {
+    width: 50%;
+    max-width: 300px;
+    display: block;
+    margin: 20px 0;
 }


### PR DESCRIPTION
## Summary
- reduce homepage image width to one-third
- add fixed header bar that hides on scroll down and shows when scrolling up
- include JS to control header visibility on all pages

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_6853acebfb2083328a30067da00f1036