### PR TITLE
Fix slideshow left-to-right animation

### DIFF
--- a/index.html
+++ b/index.html
@@ -57,8 +57,12 @@
 
             // wait for the slide-out animation before resetting position
             setTimeout(() => {
+                curr.classList.add('jump');
                 curr.classList.remove('prev');
                 curr.classList.add('next');
+                // force reflow to apply the jump immediately
+                void curr.offsetWidth;
+                curr.classList.remove('jump');
             }, 500);
         }, 3000);
     });

--- a/style.css
+++ b/style.css
@@ -93,6 +93,11 @@ main {
     transition: transform 0.5s, opacity 0.5s;
 }
 
+/* disable transition when instantly repositioning slides */
+.codex-btn .slideshow img.jump {
+    transition: none;
+}
+
 .codex-btn .slideshow img.next {
     transform: translate(-50%, -50%) translateX(100%) scale(0.8);
     opacity: 0;


### PR DESCRIPTION
## Summary
- fix slideshow to jump instantly from leftmost to rightmost image
- add CSS class to disable transition during the jump

## Testing
- `python3 test_html.py`

------
https://chatgpt.com/codex/tasks/task_e_6853d8a95d288332b52c0c5bf59158d1