### PR TITLE
Implement edge previews for slideshow

### DIFF
--- a/index.html
+++ b/index.html
@@ -38,33 +38,51 @@
     document.addEventListener('DOMContentLoaded', function() {
         const slides = document.querySelectorAll('.codex-btn .slideshow img');
         let current = 0;
+        let prev = slides.length - 1;
+
         slides.forEach((img, i) => {
-            if (i === 0) {
+            if (i === current) {
                 img.classList.add('active');
+            } else if (i === prev) {
+                img.classList.add('prev');
             } else {
                 img.classList.add('next');
             }
         });
-        setInterval(() => {
-            const curr = slides[current];
-            curr.classList.remove('active');
-            curr.classList.add('prev');
 
-            current = (current + 1) % slides.length;
-            const next = slides[current];
-            next.classList.remove('next');
-            next.classList.add('active');
+        function setActive(index) {
+            slides[current].classList.remove('active');
+            slides[current].classList.add('prev');
 
-            // wait for the slide-out animation before resetting position
-            setTimeout(() => {
-                curr.classList.add('jump');
-                curr.classList.remove('prev');
-                curr.classList.add('next');
-                // force reflow to apply the jump immediately
-                void curr.offsetWidth;
-                curr.classList.remove('jump');
-            }, 500);
-        }, 3000);
+            slides[prev].classList.remove('prev');
+            slides[prev].classList.add('next');
+
+            prev = (index - 1 + slides.length) % slides.length;
+
+            slides[prev].classList.remove('next');
+            slides[prev].classList.add('prev');
+
+            current = index;
+
+            slides[current].classList.remove('next');
+            slides[current].classList.add('active');
+        }
+
+        function showNext() {
+            const nextIndex = (current + 1) % slides.length;
+            setActive(nextIndex);
+        }
+
+        let interval = setInterval(showNext, 3000);
+
+        slides.forEach((img, i) => {
+            img.addEventListener('click', () => {
+                if (i === current) return;
+                clearInterval(interval);
+                setActive(i);
+                interval = setInterval(showNext, 3000);
+            });
+        });
     });
     </script>
 </body>

--- a/style.css
+++ b/style.css
@@ -99,8 +99,10 @@ main {
 }
 
 .codex-btn .slideshow img.next {
-    transform: translate(-50%, -50%) translateX(100%) scale(0.8);
-    opacity: 0;
+    transform: translate(-50%, -50%) translateX(90%) scale(0.8);
+    opacity: 0.5;
+    filter: grayscale(100%);
+    cursor: pointer;
 }
 
 .codex-btn .slideshow img.active {
@@ -110,8 +112,10 @@ main {
 }
 
 .codex-btn .slideshow img.prev {
-    transform: translate(-50%, -50%) translateX(-100%) scale(0.8);
-    opacity: 1;
+    transform: translate(-50%, -50%) translateX(-90%) scale(0.8);
+    opacity: 0.5;
+    filter: grayscale(100%);
+    cursor: pointer;
 }
 
 .btn .label {


### PR DESCRIPTION
## Summary
- keep previous and next images partially visible and greyed out
- allow clicking preview images to jump directly
- update slideshow classes with new preview styling

## Testing
- `python3 test_html.py`

------
https://chatgpt.com/codex/tasks/task_e_6853db6057788332ae604e1f1f88bc6c