### PR TITLE
Prevent left-to-right slideshow animation

### DIFF
--- a/style.css
+++ b/style.css
@@ -95,7 +95,8 @@ main {
 
 /* disable transition when instantly repositioning slides */
 .codex-btn .slideshow img.jump {
-    transition: none;
+    transition: none !important;
+    animation: none !important;
 }
 
 .codex-btn .slideshow img.next {


### PR DESCRIPTION
## Summary
- ensure `.jump` images never animate by disabling both `transition` and `animation`

## Testing
- `python3 test_html.py`

------
https://chatgpt.com/codex/tasks/task_e_6853e3866fd08332899229eb656146c4