### PR TITLE
Fix slideshow jump logic

### DIFF
--- a/index.html
+++ b/index.html
@@ -54,12 +54,12 @@
              slides[current].classList.remove('active');
              slides[current].classList.add('prev');
 
-             const oldPrev = prev;
-             slides[oldPrev].classList.remove('prev');
-             slides[oldPrev].classList.add('next', 'jump');
-             requestAnimationFrame(() => {
-                 slides[oldPrev].classList.remove('jump');
-             });
+            const oldPrev = prev;
+            slides[oldPrev].classList.remove('prev');
+            slides[oldPrev].classList.add('jump');
+            slides[oldPrev].classList.add('next');
+            void slides[oldPrev].offsetWidth;
+            slides[oldPrev].classList.remove('jump');
 
              prev = (index - 1 + slides.length) % slides.length;
 


### PR DESCRIPTION
## Summary
- tweak the Codex slideshow script so slides jump from left to right with no animation

## Testing
- `python3 test_html.py`

------
https://chatgpt.com/codex/tasks/task_e_6853e4f936d4833299393a7f40c51495