### PR TITLE
Add slideshow animation to GPT‑O3 button

### DIFF
--- a/index.html
+++ b/index.html
@@ -28,65 +28,74 @@
                 </div>
                 <span class="label">Codex</span>
             </a>
-            <a href="gpt-o3.html" class="btn">
-                <img src="media/Screenshot%202025-06-19%20at%2015.57.18.png" alt="O3 screenshot">
+            <a href="gpt-o3.html" class="btn o3-btn">
+                <div class="slideshow">
+                    <img src="media/row1.png" alt="O3 screenshot 1">
+                    <img src="media/row2.png" alt="O3 screenshot 2">
+                </div>
                 <span class="label">GPT-O3</span>
             </a>
         </div>
     </main>
     <script>
     document.addEventListener('DOMContentLoaded', function() {
-        const slides = document.querySelectorAll('.codex-btn .slideshow img');
-        let current = 0;
-        let prev = slides.length - 1;
+        function setupSlideshow(selector) {
+            const slides = document.querySelectorAll(selector + ' .slideshow img');
+            if (slides.length === 0) return;
+            let current = 0;
+            let prev = slides.length - 1;
 
-        slides.forEach((img, i) => {
-            if (i === current) {
-                img.classList.add('active');
-            } else if (i === prev) {
-                img.classList.add('prev');
-            } else {
-                img.classList.add('next');
+            slides.forEach((img, i) => {
+                if (i === current) {
+                    img.classList.add('active');
+                } else if (i === prev) {
+                    img.classList.add('prev');
+                } else {
+                    img.classList.add('next');
+                }
+            });
+
+            function setActive(index) {
+                slides[current].classList.remove('active');
+                slides[current].classList.add('prev');
+
+                const oldPrev = prev;
+                slides[oldPrev].classList.remove('prev');
+                slides[oldPrev].classList.add('jump');
+                slides[oldPrev].classList.add('next');
+                void slides[oldPrev].offsetWidth;
+                slides[oldPrev].classList.remove('jump');
+
+                prev = (index - 1 + slides.length) % slides.length;
+
+                slides[prev].classList.remove('next');
+                slides[prev].classList.add('prev');
+
+                current = index;
+
+                slides[current].classList.remove('next');
+                slides[current].classList.add('active');
             }
-        });
 
-         function setActive(index) {
-             slides[current].classList.remove('active');
-             slides[current].classList.add('prev');
+            function showNext() {
+                const nextIndex = (current + 1) % slides.length;
+                setActive(nextIndex);
+            }
 
-            const oldPrev = prev;
-            slides[oldPrev].classList.remove('prev');
-            slides[oldPrev].classList.add('jump');
-            slides[oldPrev].classList.add('next');
-            void slides[oldPrev].offsetWidth;
-            slides[oldPrev].classList.remove('jump');
+            let interval = setInterval(showNext, 3000);
 
-             prev = (index - 1 + slides.length) % slides.length;
-
-             slides[prev].classList.remove('next');
-             slides[prev].classList.add('prev');
-
-             current = index;
-
-             slides[current].classList.remove('next');
-             slides[current].classList.add('active');
-         }
-
-        function showNext() {
-            const nextIndex = (current + 1) % slides.length;
-            setActive(nextIndex);
+            slides.forEach((img, i) => {
+                img.addEventListener('click', () => {
+                    if (i === current) return;
+                    clearInterval(interval);
+                    setActive(i);
+                    interval = setInterval(showNext, 3000);
+                });
+            });
         }
 
-        let interval = setInterval(showNext, 3000);
-
-        slides.forEach((img, i) => {
-            img.addEventListener('click', () => {
-                if (i === current) return;
-                clearInterval(interval);
-                setActive(i);
-                interval = setInterval(showNext, 3000);
-            });
-        });
+        setupSlideshow('.codex-btn');
+        setupSlideshow('.o3-btn');
     });
     </script>
 </body>

--- a/style.css
+++ b/style.css
@@ -71,8 +71,9 @@ main {
     border-radius: 15px;
 }
 
-/* slideshow for the Codex button */
-.codex-btn .slideshow {
+/* slideshow for the Codex and O3 buttons */
+.codex-btn .slideshow,
+.o3-btn .slideshow {
     position: absolute;
     top: 10%;
     left: 10%;
@@ -82,7 +83,8 @@ main {
     border-radius: 15px;
 }
 
-.codex-btn .slideshow img {
+.codex-btn .slideshow img,
+.o3-btn .slideshow img {
     position: absolute;
     top: 50%;
     left: 50%;
@@ -94,24 +96,28 @@ main {
 }
 
 /* disable transition when instantly repositioning slides */
-.codex-btn .slideshow img.jump {
+.codex-btn .slideshow img.jump,
+.o3-btn .slideshow img.jump {
     transition: none !important;
     animation: none !important;
 }
 
-.codex-btn .slideshow img.next {
+.codex-btn .slideshow img.next,
+.o3-btn .slideshow img.next {
     transform: translate(-50%, -50%) translateX(90%) scale(0.8);
     opacity: 0.5;
     cursor: pointer;
 }
 
-.codex-btn .slideshow img.active {
+.codex-btn .slideshow img.active,
+.o3-btn .slideshow img.active {
     transform: translate(-50%, -50%) translateX(0) scale(1);
     z-index: 2;
     opacity: 1;
 }
 
-.codex-btn .slideshow img.prev {
+.codex-btn .slideshow img.prev,
+.o3-btn .slideshow img.prev {
     transform: translate(-50%, -50%) translateX(-90%) scale(0.8);
     opacity: 0.5;
     cursor: pointer;


### PR DESCRIPTION
## Summary
- add slideshow effect for Codex and O3 buttons
- include O3 images row1.png and row2.png
- update JavaScript to initialize multiple slideshows

## Testing
- `python3 test_html.py`

------
https://chatgpt.com/codex/tasks/task_e_68540274a7fc83329d6f8a5139387f2f