### PR TITLE
Fix slideshow image size

### DIFF
--- a/style.css
+++ b/style.css
@@ -93,8 +93,8 @@ main {
     position: absolute;
     top: 50%;
     left: 50%;
-    width: 100%;
-    height: 100%;
+    width: 90%;
+    height: 90%;
     object-fit: cover;
     border-radius: inherit;
     transition: transform 0.5s, opacity 0.5s;


### PR DESCRIPTION
## Summary
- shrink slideshow images inside button links so they don't fill the entire button

## Testing
- `python3 test_html.py`

------
https://chatgpt.com/codex/tasks/task_e_685416b4a7fc83329c91250bdd4d9f0b