### PR TITLE
Fix rotation animation alignment

### DIFF
--- a/index.html
+++ b/index.html
@@ -115,11 +115,17 @@
         const anim = document.getElementById('gpt4o-animation');
         const startAnchor = document.getElementById('start-anchor');
         const endAnchor = document.getElementById('end-anchor');
+        const buttons = document.querySelector('.buttons');
+        const placeholder = document.createElement('div');
+        placeholder.className = 'animation-placeholder';
+        let placeholderInserted = false;
+        let animHeight = 0;
         let start = 0, end = 0, ticking = false;
 
         function computePositions() {
             start = startAnchor.getBoundingClientRect().top + window.scrollY;
             end = endAnchor.getBoundingClientRect().top + window.scrollY;
+            animHeight = anim.getBoundingClientRect().height;
         }
 
         function updateAnimation() {
@@ -127,7 +133,13 @@
             let progress = (y - start) / (end - start);
             progress = Math.min(Math.max(progress, 0), 1);
 
-            if (progress > 0 && progress < 1) {
+            if (progress >= 0 && progress < 1) {
+                if (!placeholderInserted) {
+                    placeholder.style.height = animHeight + 'px';
+                    anim.insertAdjacentElement('afterend', placeholder);
+                    placeholderInserted = true;
+                }
+                buttons.classList.add('offscreen');
                 anim.classList.add('fixed-center');
                 let angle = -720 * progress;
                 let scale;
@@ -144,6 +156,11 @@
                 anim.style.transform =
                     'translate(-50%, -50%) rotate(' + angle + 'deg) scale(' + scale + ')';
             } else {
+                if (placeholderInserted) {
+                    placeholder.remove();
+                    placeholderInserted = false;
+                }
+                buttons.classList.remove('offscreen');
                 anim.classList.remove('fixed-center');
                 anim.style.transform = '';
                 anim.textContent = 'GPT-4o';

--- a/style.css
+++ b/style.css
@@ -47,6 +47,12 @@ main {
     padding: 20px;
     align-items: center;
 }
+.buttons.offscreen {
+    position: fixed;
+    top: 100vh;
+    left: 0;
+    width: 100%;
+}
 
 .btn {
     position: relative;
@@ -159,6 +165,11 @@ body.o3 {
     transform-origin: center;
     user-select: none;
     pointer-events: none;
+}
+.animation-placeholder {
+    width: 50vw;
+    margin: 40vh auto;
+    visibility: hidden;
 }
 
 .fixed-center {


### PR DESCRIPTION
## Summary
- keep the buttons fixed below the viewport while GPT-4o spins
- hold page layout with a placeholder for the animation element

## Testing
- `python3 -m pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68556313c4b88332af46637bdf474c6f